### PR TITLE
Add video feed and screenshot button

### DIFF
--- a/app/views/dashboard/_photo.html.erb
+++ b/app/views/dashboard/_photo.html.erb
@@ -1,0 +1,39 @@
+<video id="screenshot-vid" autoplay style="background-color:#333;height:480px;width:640px;"></video>
+<img id="screenshot-img" src="" style="background-color:#333;height:480px;width:640px;">
+<canvas style="display:none;"></canvas>
+<br/>
+<button id="screenshot-capture" class="capture-button">Capture Video</button>
+<br/>
+<br/>
+<button id="screenshot-button">Take screenshot</button>
+<script>
+  const constraints = {
+    video: true
+  };
+
+  const captureVideoButton =
+    document.querySelector('#screenshot-capture');
+  const screenshotButton = document.querySelector('#screenshot-button');
+  const img = document.querySelector('#screenshot-img');
+  const video = document.querySelector('#screenshot-vid');
+
+  const canvas = document.createElement('canvas');
+
+  captureVideoButton.onclick = function() {
+    navigator.mediaDevices.getUserMedia(constraints).
+      then(handleSuccess).catch(handleError);
+  };
+
+  screenshotButton.onclick = video.onclick = function() {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    canvas.getContext('2d').drawImage(video, 0, 0);
+    // Other browsers will fall back to image/png
+    img.src = canvas.toDataURL('image/webp');
+  };
+
+  function handleSuccess(stream) {
+    screenshotButton.disabled = false;
+    video.srcObject = stream;
+  }
+</script>

--- a/app/views/dashboard/clock_in.html.slim
+++ b/app/views/dashboard/clock_in.html.slim
@@ -1,1 +1,2 @@
 h1 Employee Clock-In
+= render "photo"

--- a/app/views/dashboard/clock_out.html.slim
+++ b/app/views/dashboard/clock_out.html.slim
@@ -1,1 +1,2 @@
 h1 Employee Clock-Out
+= render "photo"

--- a/app/views/dashboard/end_break.html.slim
+++ b/app/views/dashboard/end_break.html.slim
@@ -1,1 +1,2 @@
 h1 Employee End Break
+= render "photo"

--- a/app/views/dashboard/start_break.html.slim
+++ b/app/views/dashboard/start_break.html.slim
@@ -1,1 +1,2 @@
 h1 Employee Start Break
+= render "photo"


### PR DESCRIPTION
## Description
- Adds a front-end implementation of a sample video feed and a button to take a screenshot of the video

## GitHub Issue
#38 

## Pull Request Changes
- Used [this article](https://www.html5rocks.com/en/tutorials/getusermedia/intro/) as a guide
- Separated code into its own partial

## Screenshots
![image](https://user-images.githubusercontent.com/25378966/56480599-aa21cc80-646f-11e9-8234-6350e33c5da9.png)
