### PR TITLE
Create Person in PersonGroup

### DIFF
--- a/app/concepts/person/operations/create.rb
+++ b/app/concepts/person/operations/create.rb
@@ -1,0 +1,25 @@
+module Person
+  module Operations
+    class Create < ApplicationOperation
+      step :initialize_employee!
+      step :assign_person_id!
+      step :save!
+
+      def initialize_employee!(options, params:, **)
+        options["model"] = params[:employee]
+      end
+
+      def assign_person_id!(options, params:, **)
+        employee = options["model"]
+        employee.person_id = CreatePerson.(
+          branch_id: employee.branch_id.to_s,
+          person_name: employee.full_name
+        )
+      end
+
+      def save!(options, params:, **)
+        options["model"].save
+      end
+    end
+  end
+end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,8 @@
 class Employee < ApplicationRecord
   belongs_to :branch
   has_many :shifts
+
+  def full_name
+    [first_name, last_name].join(" ")
+  end
 end

--- a/app/services/create_person.rb
+++ b/app/services/create_person.rb
@@ -1,0 +1,17 @@
+class CreatePerson
+  def self.call(branch_id:, person_name:)
+    url = ENV["FACE_API_URL"] + "/persongroups/" + branch_id + "/persons"
+    api_key = ENV["FACE_API_KEY"]
+    response = HTTParty.post(
+      url,
+      headers: {
+        "Ocp-Apim-Subscription-Key" => api_key,
+        "Content-Type" => "application/json"
+      },
+      :body => {
+        name: person_name,
+      }.to_json
+    ).parsed_response
+    response["personId"]
+  end
+end

--- a/db/migrate/20190423021221_add_person_id_to_employee.rb
+++ b/db/migrate/20190423021221_add_person_id_to_employee.rb
@@ -1,0 +1,5 @@
+class AddPersonIdToEmployee < ActiveRecord::Migration[5.2]
+  def change
+    add_column :employees, :person_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_15_192235) do
+ActiveRecord::Schema.define(version: 2019_04_23_021221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2019_04_15_192235) do
     t.bigint "branch_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "person_id"
     t.index ["branch_id"], name: "index_employees_on_branch_id"
   end
 

--- a/spec/concepts/person/operations/create_spec.rb
+++ b/spec/concepts/person/operations/create_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+module Person
+  module Operations
+    RSpec.describe Create, vcr: { record: :once, match_requests_on: [:body] } do
+      let (:branch) { create(:branch) }
+      let (:employee) { create(:employee, branch: branch) }
+
+      it "assigns a person_id to an employee" do
+        op = described_class.(employee: employee)
+        model = op["model"]
+
+        expect(op.success?).to be_truthy
+        expect(model.person_id.length).to eq 36
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/Person_Operations_Create/assigns_a_person_id_to_an_employee.yml
+++ b/spec/fixtures/vcr_cassettes/Person_Operations_Create/assigns_a_person_id_to_an_employee.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://westus.api.cognitive.microsoft.com/face/v1.0/persongroups/1/persons
+    body:
+      encoding: UTF-8
+      string: '{"name":"MyString MyString"}'
+    headers:
+      Ocp-Apim-Subscription-Key:
+      - "[FACE_API_KEY]"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Apim-Request-Id:
+      - aefeb710-294a-42d8-bd83-381fee902d43
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 23 Apr 2019 02:22:08 GMT
+    body:
+      encoding: UTF-8
+      string: '{"personId":"7bdeebd6-25d6-4e02-9f30-c7b3af3b79e7"}'
+    http_version: 
+  recorded_at: Tue, 23 Apr 2019 02:22:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -3,4 +3,13 @@ require 'rails_helper'
 RSpec.describe Employee, type: :model do
   it { should belong_to :branch }
   it { should have_many :shifts }
+  let (:branch) { create(:branch) }
+
+  describe "#full_name" do
+    it 'appends last_name to first_name' do
+      employee = create(:employee, first_name: 'John', last_name: 'Wick', branch: branch)
+
+      expect(employee.full_name).to eq 'John Wick'
+    end
+  end
 end


### PR DESCRIPTION
## Description
- Add an operation to create a Person in a PersonGroup

## GitHub Issue
#42 

## Pull Request Changes
- Employee now has a `person_id` attribute
- `employee.full_name` returns the employee's full name
- `Person::Operations::Create` uses the PersonGroupId parameter and adds a Person to the PersonGroup given their full name, and returns a `person_id` that is persisted to the Employee model
