### PR TITLE
Add employee flow

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -23,10 +23,10 @@ class BranchesController < Dashboard::BaseController
   # POST /branches
   def create
     @branch = Branch.new(branch_params)
-    @branch.regional_manager_id = current_regional_manager.id
+    @branch.user_id = current_user.id
 
     if @branch.save
-      redirect_to @branch, notice: 'Branch was successfully created.'
+      redirect_to branches_path, notice: 'Branch was successfully created.'
     else
       render :new
     end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -22,9 +22,10 @@ class EmployeesController < Dashboard::BaseController
   # POST /employees
   def create
     @employee = Employee.new(employee_params)
+    @employee.branch_id = current_user.branch_id
 
     if @employee.save
-      redirect_to @employee, notice: 'Employee was successfully created.'
+      redirect_to employees_path, notice: 'Employee was successfully created.'
     else
       render :new
     end

--- a/app/views/branches/index.html.slim
+++ b/app/views/branches/index.html.slim
@@ -21,3 +21,5 @@ table
           = link_to 'Destroy', branch, method: :delete, data: { confirm: 'Are you sure?' }
 br
 = link_to 'New Branch', new_branch_path
+br
+= link_to 'Back', root_path, class: 'active'

--- a/app/views/branches/new.html.slim
+++ b/app/views/branches/new.html.slim
@@ -1,4 +1,5 @@
 h1
   | New Branch
 = render 'form', branch: @branch
-= link_to 'Back', branches_path
+br
+= link_to 'Cancel', branches_path

--- a/app/views/dashboard/_branch.html.slim
+++ b/app/views/dashboard/_branch.html.slim
@@ -1,2 +1,4 @@
 h1
   | Store Dashboard Page
+br
+= link_to('Employees', employees_path, class: 'active')

--- a/app/views/dashboard/_branch.html.slim
+++ b/app/views/dashboard/_branch.html.slim
@@ -2,3 +2,11 @@ h1
   | Store Dashboard Page
 br
 = link_to('Employees', employees_path, class: 'active')
+br
+= link_to('Clock-In', clock_in_path, class: 'active')
+br
+= link_to('Clock-Out', clock_out_path, class: 'active')
+br
+= link_to('Start Break', start_break_path, class: 'active')
+br
+= link_to('End Break', end_break_path, class: 'active')

--- a/app/views/dashboard/_regional.html.slim
+++ b/app/views/dashboard/_regional.html.slim
@@ -10,5 +10,3 @@ br
 = link_to('Start Break', start_break_path, class: 'active')
 br
 = link_to('End Break', end_break_path, class: 'active')
-br
-= link_to('Employees', employees_path, class: 'active')

--- a/app/views/dashboard/_regional.html.slim
+++ b/app/views/dashboard/_regional.html.slim
@@ -3,10 +3,4 @@ h1
 br
 = link_to('Invite Branch Manager', new_user_invitation_path, class: 'active')
 br
-= link_to('Clock-In', clock_in_path, class: 'active')
-br
-= link_to('Clock-Out', clock_out_path, class: 'active')
-br
-= link_to('Start Break', start_break_path, class: 'active')
-br
-= link_to('End Break', end_break_path, class: 'active')
+= link_to('Branches', branches_path, class: 'active')

--- a/app/views/employees/_form.html.slim
+++ b/app/views/employees/_form.html.slim
@@ -4,6 +4,5 @@
   .form-inputs
     = f.input :first_name
     = f.input :last_name
-    = f.association :branch
   .form-actions
     = f.button :submit

--- a/app/views/employees/index.html.slim
+++ b/app/views/employees/index.html.slim
@@ -9,9 +9,6 @@ table
         | First name
       th
         | Last name
-      th
-        | Branch
-      th[colspan="3"]
   tbody
     - @employees.each do |employee|
       tr
@@ -19,8 +16,6 @@ table
           = employee.first_name
         td
           = employee.last_name
-        td
-          = employee.branch
         td
           = link_to 'Show', employee
         td

--- a/app/views/employees/index.html.slim
+++ b/app/views/employees/index.html.slim
@@ -28,4 +28,6 @@ table
         td
           = link_to 'Destroy', employee, method: :delete, data: { confirm: 'Are you sure?' }
 br
-= link_to 'New Employee', new_employee_path
+= link_to 'Add Employee', new_employee_path
+br
+= link_to('Back', root_path, class: 'active')

--- a/app/views/employees/new.html.slim
+++ b/app/views/employees/new.html.slim
@@ -1,4 +1,5 @@
 h1
   | New Employee
 = render 'form', employee: @employee
+br
 = link_to 'Back', employees_path

--- a/app/views/employees/show.html.slim
+++ b/app/views/employees/show.html.slim
@@ -13,5 +13,5 @@ p
     | Branch:
   = @employee.branch
 = link_to 'Edit', edit_employee_path(@employee)
-|  | 
+|  |
 = link_to 'Back', employees_path

--- a/db/migrate/20190424020531_add_user_id_to_branches.rb
+++ b/db/migrate/20190424020531_add_user_id_to_branches.rb
@@ -1,5 +1,5 @@
 class AddUserIdToBranches < ActiveRecord::Migration[5.2]
   def change
-    add_column :branches, :user_id, :bigint
+    add_reference :branches, :user, foreign_key: true, index: true
   end
 end

--- a/db/migrate/20190424020531_add_user_id_to_branches.rb
+++ b/db/migrate/20190424020531_add_user_id_to_branches.rb
@@ -1,0 +1,5 @@
+class AddUserIdToBranches < ActiveRecord::Migration[5.2]
+  def change
+    add_column :branches, :user_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_04_24_020531) do
     t.datetime "updated_at", null: false
     t.datetime "trained_at"
     t.bigint "user_id"
+    t.index ["user_id"], name: "index_branches_on_user_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -95,6 +96,7 @@ ActiveRecord::Schema.define(version: 2019_04_24_020531) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "branches", "users"
   add_foreign_key "employees", "branches"
   add_foreign_key "interims", "shifts"
   add_foreign_key "users", "branches"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_23_224925) do
+ActiveRecord::Schema.define(version: 2019_04_24_020531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_04_23_224925) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "trained_at"
+    t.bigint "user_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/features/page_spec.rb
+++ b/spec/features/page_spec.rb
@@ -1,38 +1,63 @@
 require "rails_helper"
 
 RSpec.describe "Page navigation from root", type: :feature do
-  let(:regional_manager) { create(:user, :regional_manager) }
+  let(:branch_manager) { create(:user, :branch_manager) }
 
-  context "as regional manager" do
+  context "as branch manager" do
 
     it "shows you the Employee Clock-In page" do
-      sign_in_as regional_manager
+      sign_in_as branch_manager
       click_on "Clock-In"
       expect(page).to have_content "Employee Clock-In"
     end
 
     it "shows you the Employee Clock-Out page" do
-      sign_in_as regional_manager
+      sign_in_as branch_manager
       click_on "Clock-Out"
       expect(page).to have_content "Employee Clock-Out"
     end
 
     it "shows you the Employee Start Break page" do
-      sign_in_as regional_manager
+      sign_in_as branch_manager
       click_on "Start Break"
       expect(page).to have_content "Employee Start Break"
     end
 
     it "shows you the Employee End Break page" do
-      sign_in_as regional_manager
+      sign_in_as branch_manager
       click_on "End Break"
       expect(page).to have_content "Employee End Break"
     end
 
     it "shows you the employees scaffold" do
-      sign_in_as regional_manager
+      sign_in_as branch_manager
       click_on "Employees"
       expect(page).to have_current_path(employees_url, url: true)
+    end
+
+  end
+
+  let(:regional_manager) { create(:user, :regional_manager) }
+
+  context "as regional manager" do
+
+    it "shows you the Invite Branch Manager page" do
+      sign_in_as regional_manager
+      click_on "Invite Branch Manager"
+      expect(page).to have_content "Send invitation"
+    end
+
+    it "shows you the Branches page" do
+      sign_in_as regional_manager
+      click_on "Branches"
+      expect(page).to have_content "Branches"
+    end
+
+    it "shows you the New Branch pages" do
+      sign_in_as regional_manager
+      click_on "Branches"
+      click_on "New Branch"
+      expect(page).to have_content "New Branch"
     end
 
   end


### PR DESCRIPTION
## Description
Describe your changes made in the context of a user/technical user.
- Removed `Employee` clock in/out, start/end break functionality from `Regional Manager` Dashboard
- Added `Employee` clock in/out, start/end break functionality to `Branch Manager` Dashboard
- Added `branch_id` attribute to `branches` table to associate a `regional manager` with a `branch`
- Add `Branches` button on `regional manager` dashboard
- When a `regional manager` creates a new `branch` the `branch_id` for the new `branch` is set to the current `regional manager` id

## GitHub Issue
Place a link to the GitHub issue:
#48 

## Pull Request Changes
List changes made in the context of a developer.
- Removed `Employee` clock in/out, start/end break functionality from `Regional Manager` Dashboard
- Added `Employee` clock in/out, start/end break functionality to `Branch Manager` Dashboard
- Added `branch_id` attribute to `branches` table to associate a `regional manager` with a `branch`
- Add `Branches` button on `regional manager` dashboard
- When a `regional manager` creates a new `branch` the `branch_id` for the new `branch` is set to the current `regional manager` id

## Screenshots (optional)
Take screenshots whenever there are UI changes
![Screen Shot 2019-04-23 at 11 00 40 PM](https://user-images.githubusercontent.com/27448527/56635810-c4001280-661b-11e9-9d32-fadd02581379.png)
![Screen Shot 2019-04-23 at 10 59 30 PM](https://user-images.githubusercontent.com/27448527/56635813-c5c9d600-661b-11e9-86ea-d5d885c661ba.png)
![Screen Shot 2019-04-23 at 10 59 15 PM](https://user-images.githubusercontent.com/27448527/56635816-c7939980-661b-11e9-86c5-cd2b14dc36b5.png)


